### PR TITLE
Objects as JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ SDL_gfx-2.0.24/
 *.o
 yatc
 yatc_cli
+dat2json_cli
 Tibia.pic
 Tibia.dat
 Tibia.spr

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -165,3 +165,113 @@ filegroup(
         "//net:protocolgame854.cpp",
     ],
 )
+
+cc_library(
+    name = "dat2json_cli_lib",
+    defines = ["CLI_ONLY=1", "BAZEL_BUILD=1"] + select({
+        "//conditions:default": [],
+        "//:windows": ["WIN32=1",],
+        "//:windows_msys": ["WIN32=1",],
+        "//:windows_msvc": ["WIN32=1",],
+    }),
+    srcs = [
+        "creatureui.cpp", "//:creatureui.h",
+        "thingui.cpp", "//:thingui.h",
+        "effectui.cpp", "//:effectui.h",
+        "objects.cpp", "//:objects.h",
+        "distanceui.cpp", "//:distanceui.h",
+        "itemui.cpp", "//:itemui.h",
+        "notifications.cpp", "//:notifications.h",
+        
+        "//gamecontent:inventory.cpp",
+        "//gamecontent:globalvars.cpp",
+        "//gamecontent:creature.cpp",
+        "//gamecontent:map.cpp",
+        "//gamecontent:container.cpp",
+
+        "//:stdinttypes.h",
+        "//:sprite.h",
+        "//:defines.h",
+
+        "//gamecontent:creature.h",
+        "//gamecontent:thing.h",
+        "//gamecontent:enums.h",
+        "//gamecontent:position.h",
+        "//gamecontent:globalvars.h",
+        "//gamecontent:container.h",
+        "//gamecontent:itemcontainer.h",
+        "//gamecontent:shop.h",
+        "//gamecontent:inventory.h",
+        "//gamecontent:map.h",
+        "//gamecontent:item.h",
+        "//gamecontent:viplist.h",
+
+        "//net:encryption.cpp",
+        "//net:networkmessage.cpp",
+        "//net:connection.cpp",
+
+        "//net:connection.h",
+        "//net:networkmessage.h",
+        "//net:encryption.h",
+        "//net:protocolconfig.h",
+        "//net:protocolconfig.cpp",
+        "//net:protocolgame.h",
+        "//net:protocollogin.h",
+        "//net:protocollogin.cpp",
+        #"//net:rsa.h",
+        #"//net:rsa.cpp",
+
+        "//:util.cpp",
+        "//:util.h",
+        "//:product.h",
+        "//:macutil.h",
+
+        ":protocolgamehdrs",
+        "dat2json_cli.cpp",
+    ],
+    deps = [
+        "//:debugprint",
+        "//:fassert",
+        
+        "//net:enum_hdr",
+        "@tommath//:tommath",
+        #"//:yatc_lib", # We could pull in far less stuff. See Makefile.
+    ] + select({
+        "//:darwin": [
+            "@libsdl12//:sdlmain",
+            "//:macclipboard",
+            "//:macutil",
+            "@libsdl12//:sdl", # util.h is pulling in SDL/SDL_endian.h
+        ],
+        "//conditions:default": [
+            "@libsdl12//:sdl", # util.h is pulling in SDL/SDL_endian.h
+	    "@libsdl12//:sdlmain", # and because of that we pull in SDL_main too
+        ],
+    }) + select({
+        ":login_only": [],
+        "//conditions:default": [
+          "//net:protocols", # FIXME: This is pulling in REALLY a lot, incl chunks/all of glict. And yet it doesn't build.
+        ],
+    }),
+    data = [
+        "@tibia854//:Tibia.dat",
+    ],
+    copts = select({
+        "//conditions:default": ["-isystem external/tommath"],
+	"//:windows": ["-I external/tommath"],
+	"//:windows_msvc": ["-I external/tommath"],
+    }),
+    linkopts = select({
+        "//conditions:default": [],
+	"//:windows": ["-DEFAULTLIB:ws2_32", "-DEFAULTLIB:shell32"],
+	"//:windows_msvc": ["-DEFAULTLIB:ws2_32", "-DEFAULTLIB:shell32"],
+    }),
+)
+
+cc_binary(
+    name = "dat2json_cli",
+    deps = [
+        ":dat2json_cli_lib",
+    ],
+)
+

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -168,7 +168,7 @@ filegroup(
 
 cc_library(
     name = "dat2json_cli_lib",
-    defines = ["CLI_ONLY=1", "BAZEL_BUILD=1"] + select({
+    defines = ["CLI_ONLY=1", "HAVE_TOMMATH=1", "BAZEL_BUILD=1"] + select({
         "//conditions:default": [],
         "//:windows": ["WIN32=1",],
         "//:windows_msys": ["WIN32=1",],
@@ -178,7 +178,8 @@ cc_library(
         "creatureui.cpp", "//:creatureui.h",
         "thingui.cpp", "//:thingui.h",
         "effectui.cpp", "//:effectui.h",
-        "objects.cpp", "//:objects.h",
+        #"objects.cpp",
+        "//:objects.h",
         "distanceui.cpp", "//:distanceui.h",
         "itemui.cpp", "//:itemui.h",
         "notifications.cpp", "//:notifications.h",
@@ -218,15 +219,23 @@ cc_library(
         "//net:protocolgame.h",
         "//net:protocollogin.h",
         "//net:protocollogin.cpp",
-        #"//net:rsa.h",
-        #"//net:rsa.cpp",
+        "//net:rsa.h",
+        "//net:rsa.cpp",
 
         "//:util.cpp",
         "//:util.h",
         "//:product.h",
         "//:macutil.h",
 
+        "//gamecontent:item.cpp",
+        "//gamecontent:viplist.cpp",
+        "//:objects.cpp",
+        "//:options.cpp", "//:options.h", "//:confighandler.h", "//:confighandler.cpp",
+        "//:bigint.h",
+        "//:bigint.cpp",
+
         ":protocolgamehdrs",
+	":protocolgamesrcs", # why?
         "dat2json_cli.cpp",
     ],
     deps = [
@@ -255,6 +264,8 @@ cc_library(
     }),
     data = [
         "@tibia854//:Tibia.dat",
+        "@tibia854//:Tibia.spr",
+        "@tibia854//:Tibia.pic",
     ],
     copts = select({
         "//conditions:default": ["-isystem external/tommath"],

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,10 @@
 CXXFLAGS=-DCLI_ONLY -DLOGIN_ONLY -DHAVE_GMP_H=1
 CFLAGS=-DCLI_ONLY -DLOGIN_ONLY -DHAVE_GMP_H=1
-OBJS=yatc_cli.o ../net/connection.o ../net/networkmessage.o ../debugprint.o ../util.o notifications.o ../gamecontent/creature.o ../gamecontent/container.o ../gamecontent/globalvars.o ../gamecontent/inventory.o ../gamecontent/map.o creatureui.o thingui.o distanceui.o effectui.o objects.o ../net/protocolconfig.o ../net/rsa.o ../net/encryption.o ../net/protocollogin.o
-yatc_cli: $(OBJS)
-	g++ $(OBJS) -lSDL -lgmp -o yatc_cli
+OBJS=../net/connection.o ../net/networkmessage.o ../debugprint.o ../util.o notifications.o ../gamecontent/creature.o ../gamecontent/container.o ../gamecontent/globalvars.o ../gamecontent/inventory.o ../gamecontent/map.o creatureui.o thingui.o distanceui.o effectui.o ../net/protocolconfig.o ../net/rsa.o ../net/encryption.o ../net/protocollogin.o
+all: yatc_cli dat2json_cli
+yatc_cli: $(OBJS) yatc_cli.o objects.o
+	g++ yatc_cli.o $(OBJS) objects.o -lSDL -lgmp -o yatc_cli
+dat2json_cli: $(OBJS) dat2json_cli.o ../objects.o ../options.o ../confighandler.o
+	g++ dat2json_cli.o ../objects.o ../options.o ../confighandler.o $(OBJS) -lSDL -lgmp -o dat2json_cli
 clean:
-	rm $(OBJS) yatc_cli
+	rm $(OBJS) yatc_cli yatc_cli.o dat2json_cli dat2json_cli.o ../objects.o objects.o ../options.o ../confighandler.o

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,3 +13,23 @@ not been eliminated.
 
 The client is just for experimentation, and thus no care was taken to make it
 autoconf'igurable.
+
+It can be build with either `make` or:
+
+```
+bazel build --define LOGIN_ONLY=1 :yatc_cli
+```
+
+`LOGIN_ONLY` is required at this time. Gameworld connections are not supported
+at this time.
+
+## dat2json
+
+This is also the directory where, at this time, it made the most sense to place
+dat2json. It can be built with either `make` or:
+
+```
+bazel build --define LOGIN_ONLY=1 //cli:dat2json_cli
+```
+
+`LOGIN_ONLY` is required at this time.

--- a/cli/dat2json_cli.cpp
+++ b/cli/dat2json_cli.cpp
@@ -37,11 +37,17 @@ unsigned int g_frameDiff = 0;
 Connection *g_connection = NULL;
 
 int main(int argc, char** argv) {
+    yatc_fopen_init(argv[0]);
+    ClientVersion_t proto = CLIENT_VERSION_854;
     auto i = Objects::getInstance();
     if (argc != 3) {
         fprintf(stderr, "usage: %s datfile jsonfile\n", argv[0]);
         return 1;
     }
+    std::cout << "Warning: In case of crash after this line check you put Tibia.{dat,spr,pic} in CWD." << std::endl << std::flush;
+    ProtocolConfig::getInstance().setServerType(SERVER_OTSERV);
+    ProtocolConfig::getInstance().setVersion(CLIENT_OS_WIN, proto);
+    ProtocolConfig::getInstance().setVersionOverride(CLIENT_VERSION_AUTO);
     i->loadDat(argv[1]);
     
     std::ofstream outFile;

--- a/cli/dat2json_cli.cpp
+++ b/cli/dat2json_cli.cpp
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////
+// Yet Another Tibia Client
+//////////////////////////////////////////////////////////////////////
+// CLI version.
+//////////////////////////////////////////////////////////////////////
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+//////////////////////////////////////////////////////////////////////
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include "../util.h"
+#include "../objects.h"
+#include "../options.h"
+#include "../net/connection.h"
+
+#if BAZEL_BUILD && WIN32
+#include <SDL/SDL.h> // Give SDL a chance to rename main() for sake of SDL_main.
+#endif
+
+std::string g_recordfilename="debugrecord.rec";
+
+unsigned int g_frameTime = 0;
+unsigned int g_frameDiff = 0;
+Connection *g_connection = NULL;
+
+int main(int argc, char** argv) {
+    auto i = Objects::getInstance();
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s datfile jsonfile\n", argv[0]);
+        return 1;
+    }
+    i->loadDat(argv[1]);
+    
+    std::ofstream outFile;
+	outFile.open(argv[2]);
+	i->asJSON(outFile);
+	outFile.close();
+
+    return 0;
+}

--- a/objects.cpp
+++ b/objects.cpp
@@ -539,6 +539,8 @@ bool Objects::load780plus(const char* filename)
 	fclose(fp);
 	m_datLoaded = true;
 
+	asJSON(std::cout);
+
 	return true;
 }
 
@@ -1000,4 +1002,18 @@ ObjectType* Objects::getEffectType(uint16_t id)
 ObjectType* Objects::getDistanceType(uint16_t id)
 {
 	return m_distance.getElement(id);
+}
+
+void Objects::asJSON(std::ostream &o) {
+	o << "{" << std::endl;
+	o << "\t'items': {" << std::endl;
+	//for (std::vector<ObjectType*>::iterator it = m_item.begin(); it != m_item.end(); it++) {
+	for (int i = 0; i < m_item.size(); i++) {
+		ObjectType *oType = m_item.getElement(i);
+		o << "\t\t'id': " << oType->id << "," << std::endl;
+		o << "\t\t'width': " << oType->width << "," << std::endl;
+		o << "\t\t'height': " << oType->height << "" << std::endl;
+	}
+	o << "\t}" << std::endl;
+	o << "}" << std::endl;
 }

--- a/objects.cpp
+++ b/objects.cpp
@@ -20,7 +20,12 @@
 
 #include <iostream>
 #include "objects.h"
+#ifndef CLI_ONLY
 #include "engine.h" // used to create engine specific sprites
+#else
+#include <map>
+#include "fassert.h"
+#endif
 #include "util.h"
 #include "options.h"
 #include "net/protocolconfig.h"
@@ -112,7 +117,9 @@ void ObjectType::loadGfx()
 
     if (m_gfx.size() != numsprites) { // graphics not loaded yet?
         for(uint32_t i = 0; i < numsprites; i++){
+#ifndef CLI_ONLY
             m_gfx.insert(m_gfx.end(), g_engine->createSprite("Tibia.spr", imageData[i]));
+#endif
         }
     }
 
@@ -540,11 +547,6 @@ bool Objects::load780plus(const char* filename)
 
 	fclose(fp);
 	m_datLoaded = true;
-
-	std::ofstream outFile;
-	outFile.open("/tmp/Tibia.dat.json");
-	asJSON(outFile);
-	outFile.close();
 
 	return true;
 }

--- a/objects.cpp
+++ b/objects.cpp
@@ -26,6 +26,8 @@
 #include "net/protocolconfig.h"
 #include "product.h"
 
+#include <fstream>
+
 #ifdef HAVE_CONFIG_H
 	#include "config.h"
 #endif
@@ -539,7 +541,10 @@ bool Objects::load780plus(const char* filename)
 	fclose(fp);
 	m_datLoaded = true;
 
-	asJSON(std::cout);
+	std::ofstream outFile;
+	outFile.open("/tmp/Tibia.dat.json");
+	asJSON(outFile);
+	outFile.close();
 
 	return true;
 }
@@ -1006,14 +1011,39 @@ ObjectType* Objects::getDistanceType(uint16_t id)
 
 void Objects::asJSON(std::ostream &o) {
 	o << "{" << std::endl;
-	o << "\t'items': {" << std::endl;
+	o << "\t'items': [" << std::endl;
 	//for (std::vector<ObjectType*>::iterator it = m_item.begin(); it != m_item.end(); it++) {
-	for (int i = 0; i < m_item.size(); i++) {
+	for (int i = 100; i < m_item.size(); i++) {
 		ObjectType *oType = m_item.getElement(i);
-		o << "\t\t'id': " << oType->id << "," << std::endl;
-		o << "\t\t'width': " << oType->width << "," << std::endl;
-		o << "\t\t'height': " << oType->height << "" << std::endl;
+		if (oType == NULL) continue;
+		o << "\t\t{" << std::endl;
+		o << "\t\t\t'id': " << oType->id << "," << std::endl;
+		o << "\t\t\t'width': " << oType->width << "," << std::endl;
+		o << "\t\t\t'height': " << oType->height << "," << std::endl;
+		if((oType->width > 1) || (oType->height > 1)){
+			o << "\t\t\t'renderSize' : " << oType->rendersize << "," << std::endl;
+		}
+
+		o << "\t\t\t'blendFrames': " << oType->blendframes << "," << std::endl;
+		o << "\t\t\t'xDiv': " << oType->xdiv << "," << std::endl;
+		o << "\t\t\t'yDiv': " << oType->ydiv << "," << std::endl;
+		o << "\t\t\t'zDiv': " << oType->zdiv << "," << std::endl;
+		o << "\t\t\t'animCount': " << oType->animcount << "," << std::endl;
+		o << "\t\t\t'numSprites': " << oType->numsprites << "," << std::endl;
+		o << "\t\t\t'sprites': [" << std::endl;
+		for(unsigned int i = 0; i < oType->numsprites; i++) {
+			o << "\t\t\t\t" << oType->imageData[i];
+			if (i < oType->numsprites - 1)
+				o << ",";
+			o << std::endl;
+		}
+		o << "\t\t\t]" << std::endl;
+
+		if (i < m_item.size()-1)
+			o << "\t\t}," << std::endl;
+		else
+			o << "\t\t}" << std::endl;
 	}
-	o << "\t}" << std::endl;
+	o << "\t]" << std::endl;
 	o << "}" << std::endl;
 }

--- a/objects.cpp
+++ b/objects.cpp
@@ -1011,26 +1011,33 @@ ObjectType* Objects::getDistanceType(uint16_t id)
 
 void Objects::asJSON(std::ostream &o) {
 	o << "{" << std::endl;
-	o << "\t'items': [" << std::endl;
+	o << "\t\"items\": [" << std::endl;
+	bool first = true;
 	//for (std::vector<ObjectType*>::iterator it = m_item.begin(); it != m_item.end(); it++) {
 	for (int i = 100; i < m_item.size(); i++) {
 		ObjectType *oType = m_item.getElement(i);
 		if (oType == NULL) continue;
-		o << "\t\t{" << std::endl;
-		o << "\t\t\t'id': " << oType->id << "," << std::endl;
-		o << "\t\t\t'width': " << oType->width << "," << std::endl;
-		o << "\t\t\t'height': " << oType->height << "," << std::endl;
+
+		if (first)
+			o << "\t\t{" << std::endl;
+		else
+			o << "," << std::endl << "\t\t{" << std::endl;
+		first = false;
+
+		o << "\t\t\t\"id\": " << oType->id << "," << std::endl;
+		o << "\t\t\t\"width\": " << oType->width << "," << std::endl;
+		o << "\t\t\t\"height\": " << oType->height << "," << std::endl;
 		if((oType->width > 1) || (oType->height > 1)){
-			o << "\t\t\t'renderSize' : " << oType->rendersize << "," << std::endl;
+			o << "\t\t\t\"renderSize\" : " << oType->rendersize << "," << std::endl;
 		}
 
-		o << "\t\t\t'blendFrames': " << oType->blendframes << "," << std::endl;
-		o << "\t\t\t'xDiv': " << oType->xdiv << "," << std::endl;
-		o << "\t\t\t'yDiv': " << oType->ydiv << "," << std::endl;
-		o << "\t\t\t'zDiv': " << oType->zdiv << "," << std::endl;
-		o << "\t\t\t'animCount': " << oType->animcount << "," << std::endl;
-		o << "\t\t\t'numSprites': " << oType->numsprites << "," << std::endl;
-		o << "\t\t\t'sprites': [" << std::endl;
+		o << "\t\t\t\"blendFrames\": " << oType->blendframes << "," << std::endl;
+		o << "\t\t\t\"xDiv\": " << oType->xdiv << "," << std::endl;
+		o << "\t\t\t\"yDiv\": " << oType->ydiv << "," << std::endl;
+		o << "\t\t\t\"zDiv\": " << oType->zdiv << "," << std::endl;
+		o << "\t\t\t\"animCount\": " << oType->animcount << "," << std::endl;
+		o << "\t\t\t\"numSprites\": " << oType->numsprites << "," << std::endl;
+		o << "\t\t\t\"sprites\": [" << std::endl;
 		for(unsigned int i = 0; i < oType->numsprites; i++) {
 			o << "\t\t\t\t" << oType->imageData[i];
 			if (i < oType->numsprites - 1)
@@ -1039,11 +1046,10 @@ void Objects::asJSON(std::ostream &o) {
 		}
 		o << "\t\t\t]" << std::endl;
 
-		if (i < m_item.size()-1)
-			o << "\t\t}," << std::endl;
-		else
-			o << "\t\t}" << std::endl;
+		//o << "\t\t\t, \"_comment\": \"" << i << " out of " << m_item.size() << "\"" << std::endl;
+		o << "\t\t}";
 	}
+	o << std::endl;
 	o << "\t]" << std::endl;
 	o << "}" << std::endl;
 }

--- a/objects.h
+++ b/objects.h
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <vector>
 
+#include <iostream>
+
 template<typename A>
 class Array{
 public:
@@ -169,6 +171,8 @@ protected:
 	Array<ObjectType*> m_outfit;
 	Array<ObjectType*> m_effect;
 	Array<ObjectType*> m_distance;
+
+	void asJSON(std::ostream &o) ;
 };
 
 #endif

--- a/objects.h
+++ b/objects.h
@@ -172,7 +172,9 @@ protected:
 	Array<ObjectType*> m_effect;
 	Array<ObjectType*> m_distance;
 
-	void asJSON(std::ostream &o) ;
+public:
+	// Public for use in dat2json_cli
+	void asJSON(std::ostream &o);
 };
 
 #endif


### PR DESCRIPTION
(This description should also be updated before the merge.)

To merge this, the creation of the output file should be made optional or -- better -- moved to a separate tool. Certainly the output filename should not be constant and in `/tmp`.

Ideally, we'd output the data with an actual JSON encoder -- except adding a new dependency just for a one-off output of predictably-formatted data would be too much.