### PR TITLE
.github/workflows: Pass `BUILDBUDDY_ORG_API_KEY` to ci-bazel as a secret

### DIFF
--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -2,6 +2,9 @@ name: Bazel CI
 
 on:
   workflow_call:
+    secrets:
+      BUILDBUDDY_ORG_API_KEY:
+        required: false
 
 # Not using 'inputs' here, since we take no inputs at this time -- just the 'github' context.
 # Note: on type workflow_run commit message would be github.event.workflow_run.head_commit.message

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,5 @@ jobs:
 
   bazel:
     uses: ./.github/workflows/ci-bazel.yml
+    secrets:
+      BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}


### PR DESCRIPTION
`ci-bazel.yml` is technically a "reusable" workflow, so the secret must be explicitly specified to be allowed in the child workflow.